### PR TITLE
Add Swagger API Documentation

### DIFF
--- a/RaspberryPi/aboavobr.raspberrypi/Controllers/AppController.cs
+++ b/RaspberryPi/aboavobr.raspberrypi/Controllers/AppController.cs
@@ -3,27 +3,31 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace aboavobr.raspberrypi.Controllers
 {
-    [Route("api/[controller]")]
-    [ApiController]
-    public class AppController : ControllerBase
-    {
-        private readonly ISerialCommunicationService serialCommunicaitonService;
+   [Route("api/[controller]")]
+   [ApiController]
+   public class AppController : ControllerBase
+   {
+      private readonly ISerialCommunicationService serialCommunicaitonService;
 
-        public AppController(ISerialCommunicationService serialCommunicaitonService)
-        {
-            this.serialCommunicaitonService = serialCommunicaitonService;
-        }
+      public AppController(ISerialCommunicationService serialCommunicaitonService)
+      {
+         this.serialCommunicaitonService = serialCommunicaitonService;
+      }
 
-        [HttpGet("heartbeat")]
-        public ActionResult GetHeartbeat()
-        {
-            return Ok();
-        }
+      [HttpGet("heartbeat")]
+      public ActionResult GetHeartbeat()
+      {
+         return Ok();
+      }
 
-        [HttpGet("battery")]
-        public ActionResult<int> GetBatteryLife()
-        {
-            return new ActionResult<int>(serialCommunicaitonService.GetBatteryLife());
-        }
-    }
+      /// <summary>
+      /// Gets the battery life in percentage.
+      /// </summary>
+      /// <returns>The battery state in percentage</returns>
+      [HttpGet("battery")]
+      public ActionResult<int> GetBatteryLife()
+      {
+         return new ActionResult<int>(serialCommunicaitonService.GetBatteryLife());
+      }
+   }
 }

--- a/RaspberryPi/aboavobr.raspberrypi/Startup.cs
+++ b/RaspberryPi/aboavobr.raspberrypi/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Swashbuckle.AspNetCore.Swagger;
 
 namespace aboavobr.raspberrypi
 {
@@ -21,6 +22,16 @@ namespace aboavobr.raspberrypi
       public void ConfigureServices(IServiceCollection services)
       {
          services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+         services.AddSwaggerGen(c =>
+         {
+            c.SwaggerDoc(
+               "v1",
+               new Info
+               {
+                  Title = "ABOAVOBR Rest API",
+                  Version = "v1"                  
+               });
+         });
 
          services.AddSingleton<ISerialPortFactory, SerialPortFactory>();
          services.AddSingleton<ISerialCommunicationService, SerialCommunicationService>();
@@ -49,6 +60,9 @@ namespace aboavobr.raspberrypi
          {
             app.UseHsts();
          }
+
+         app.UseSwagger();
+         app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "ABOAVOBR Rest API v1"));
 
          app.UseMvc();
       }

--- a/RaspberryPi/aboavobr.raspberrypi/aboavobr.raspberrypi.csproj
+++ b/RaspberryPi/aboavobr.raspberrypi/aboavobr.raspberrypi.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.0.2105168" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" />
     <PackageReference Include="MonoSerialPort" Version="1.0.15" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="4.0.1" />
     <PackageReference Include="Unosquare.Raspberry.IO" Version="0.18.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds Swashbuckle package and exposes swagger REST API documentation under <ip>:<port>/swagger